### PR TITLE
fix: set globalPrefix after load

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -241,6 +241,9 @@ class Config {
     // symbols, as that module also does a bunch of get operations
     this[_loaded] = true
 
+    // set proper globalPrefix now that everything is loaded
+    this.globalPrefix = this.get('prefix')
+
     process.emit('time', 'config:load:setEnvs')
     this.setEnvs()
     process.emit('timeEnd', 'config:load:setEnvs')

--- a/test/index.js
+++ b/test/index.js
@@ -194,6 +194,7 @@ loglevel = yolo
     const env = {
       npm_config_foo: 'from-env',
       npm_config_global: '',
+      npm_config_prefix: '/something',
     }
     const config = new Config({
       npmPath: `${path}/npm`,
@@ -206,7 +207,12 @@ loglevel = yolo
       shorthands,
       defaults,
     })
+
+    t.equal(config.globalPrefix, null, 'globalPrefix missing before load')
+
     await config.load()
+
+    t.equal(config.globalPrefix, resolve('/something'), 'env-defined prefix should have been loaded')
 
     t.equal(config.get('global', 'env'), undefined, 'empty env is missing')
     t.equal(config.get('global'), false, 'empty env is missing')


### PR DESCRIPTION
`globalPrefix` is a regular config property that defaults to `null` and
is updated on `loadGlobalPrefix()` which happens before user config load

This change forces the updating of `globalPrefix` post-load in order to
allow user-defined `prefix` to work.

fix: https://github.com/npm/cli/issues/1755