### PR TITLE
Allow unknown envs in configs to be passed through

### DIFF
--- a/lib/env-replace.js
+++ b/lib/env-replace.js
@@ -3,12 +3,11 @@
 const envExpr = /(\\*)\$\{([^}]+)\}/g
 
 module.exports = (f, env) => f.replace(envExpr, (orig, esc, name) => {
+  const val = env[name] !== undefined ? env[name] : `\$\{${name}\}`
+
   // consume the escape chars that are relevant.
   if (esc.length % 2)
     return orig.substr((esc.length + 1) / 2)
 
-  if (undefined === env[name])
-    throw new Error('Failed to replace env in config: ' + orig)
-
-  return (esc.substr(esc.length / 2)) + env[name]
+  return (esc.substr(esc.length / 2)) + val
 })

--- a/test/env-replace.js
+++ b/test/env-replace.js
@@ -8,6 +8,6 @@ const env = {
 
 t.equal(envReplace('\\${foo}', env),  '${foo}')
 t.equal(envReplace('\\\\${foo}', env),  '\\bar')
-t.throws(() => envReplace('${baz}', env), {
-  message: 'Failed to replace env in config: ${baz}',
-})
+t.equal(envReplace('${baz}', env), '${baz}')
+t.equal(envReplace('\\${baz}', env), '${baz}')
+t.equal(envReplace('\\\\${baz}', env), '\\${baz}')


### PR DESCRIPTION
If a user does something like `npm exec -c 'echo ${FOO}'` then we should
not fail if there is no FOO environment variable, and instead just pass
it through as-is.

<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->


## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
