### PR TITLE
generate user-agent string as part of config loading

### DIFF
--- a/lib/get-user-agent.js
+++ b/lib/get-user-agent.js
@@ -1,0 +1,13 @@
+// Accepts a config object, returns a user-agent string
+const getUserAgent = (config) => {
+  const ciName = config.get('ci-name')
+  return config.get('user-agent')
+    .replace(/\{node-version\}/gi, config.get('node-version'))
+    .replace(/\{npm-version\}/gi, config.get('npm-version'))
+    .replace(/\{platform\}/gi, process.platform)
+    .replace(/\{arch\}/gi, process.arch)
+    .replace(/\{ci\}/gi, ciName ? `ci/${ciName}` : '')
+    .trim()
+}
+
+module.exports = getUserAgent

--- a/lib/index.js
+++ b/lib/index.js
@@ -47,6 +47,7 @@ const envReplace = require('./env-replace.js')
 const parseField = require('./parse-field.js')
 const typeDescription = require('./type-description.js')
 const setEnvs = require('./set-envs.js')
+const getUserAgent = require('./get-user-agent.js')
 
 // types that can be saved back to
 const confFileTypes = new Set([
@@ -243,6 +244,10 @@ class Config {
 
     // set proper globalPrefix now that everything is loaded
     this.globalPrefix = this.get('prefix')
+
+    process.emit('time', 'config:load:setUserAgent')
+    this.setUserAgent()
+    process.emit('timeEnd', 'config:load:setUserAgent')
 
     process.emit('time', 'config:load:setEnvs')
     this.setEnvs()
@@ -692,6 +697,12 @@ class Config {
       configurable: true,
       writable: true,
     })
+  }
+
+  // the user-agent configuration is a template that gets populated
+  // with some variables, that takes place here
+  setUserAgent () {
+    this.set('user-agent', getUserAgent(this))
   }
 
   // set up the environment object we have with npm_config_* environs

--- a/test/get-user-agent.js
+++ b/test/get-user-agent.js
@@ -1,0 +1,29 @@
+const getUserAgent = require('../lib/get-user-agent.js')
+
+const t = require('tap')
+
+t.test('correctly generates a user-agent outside of ci', t => {
+  const config = new Map(Object.entries({
+    'user-agent': 'npm/{npm-version} node/{node-version} {platform} {arch} {ci}',
+    'node-version': 'v14.12.0',
+    'npm-version': '7.0.0',
+    'ci-name': null
+  }))
+
+  const userAgent = getUserAgent(config)
+  t.equal(userAgent, `npm/7.0.0 node/v14.12.0 ${process.platform} ${process.arch}`)
+  t.end()
+})
+
+t.test('correctly generates a user-agent inside of ci', t => {
+  const config = new Map(Object.entries({
+    'user-agent': 'npm/{npm-version} node/{node-version} {platform} {arch} {ci}',
+    'node-version': 'v14.12.0',
+    'npm-version': '7.0.0',
+    'ci-name': 'travis'
+  }))
+
+  const userAgent = getUserAgent(config)
+  t.equal(userAgent, `npm/7.0.0 node/v14.12.0 ${process.platform} ${process.arch} ci/travis`)
+  t.end()
+})


### PR DESCRIPTION
This relocates the logic to turn a user-agent template into its final form from the cli to here, which has the added bonus of restoring the `npm_config_user_agent` environment variable as well.

There will be accompanying changes to the cli to ensure that the default values for `npm-version` and `ci-name` are passed in appropriately, as well as removing the user-agent related code from there.

Related to: https://github.com/npm/cli/issues/1834