### PR TITLE
fix: empty user-agent config

### DIFF
--- a/lib/get-user-agent.js
+++ b/lib/get-user-agent.js
@@ -1,7 +1,7 @@
 // Accepts a config object, returns a user-agent string
 const getUserAgent = (config) => {
   const ciName = config.get('ci-name')
-  return config.get('user-agent')
+  return (config.get('user-agent') || '')
     .replace(/\{node-version\}/gi, config.get('node-version'))
     .replace(/\{npm-version\}/gi, config.get('npm-version'))
     .replace(/\{platform\}/gi, process.platform)

--- a/test/get-user-agent.js
+++ b/test/get-user-agent.js
@@ -2,6 +2,14 @@ const getUserAgent = require('../lib/get-user-agent.js')
 
 const t = require('tap')
 
+t.test('missing user-agent', t => {
+  const config = new Map()
+
+  const userAgent = getUserAgent(config)
+  t.equal(userAgent, '', 'should return an empty string')
+  t.end()
+})
+
 t.test('correctly generates a user-agent outside of ci', t => {
   const config = new Map(Object.entries({
     'user-agent': 'npm/{npm-version} node/{node-version} {platform} {arch} {ci}',


### PR DESCRIPTION
Found it while testing empty config values in `init-package-json` tests, without defaulting to an empty string the `replace` calls are going to throw.