### PR TITLE
Force 'path' type options to be strings

### DIFF
--- a/lib/parse-field.js
+++ b/lib/parse-field.js
@@ -15,7 +15,7 @@ const parseField = (f, key, opts, listElement = false) => {
   const typeList = new Set([].concat(types[key]))
   const isPath = typeList.has(typeDefs.path.type)
   const isBool = typeList.has(typeDefs.Boolean.type)
-  const isString = typeList.has(typeDefs.String.type)
+  const isString = isPath || typeList.has(typeDefs.String.type)
   const isUmask = typeList.has(typeDefs.Umask.type)
   const isNumber = typeList.has(typeDefs.Number.type)
   const isList = !listElement && typeList.has(Array)
@@ -38,7 +38,7 @@ const parseField = (f, key, opts, listElement = false) => {
 
   // string types can be the string 'true', 'false', etc.
   // otherwise, parse these values out
-  if (!isString) {
+  if (!isString && !isPath && !isNumber) {
     switch (f) {
       case 'true': return true
       case 'false': return false

--- a/lib/type-defs.js
+++ b/lib/type-defs.js
@@ -10,6 +10,13 @@ const validateSemver = (data, k, val) => {
   data[k] = valid
 }
 
+const noptValidatePath = nopt.typeDefs.path.validate
+const validatePath = (data, k, val) => {
+  if (typeof val !== 'string')
+    return false
+  return noptValidatePath(data, k, val)
+}
+
 // add descriptions so we can validate more usefully
 module.exports = {
   ...nopt.typeDefs,
@@ -29,6 +36,7 @@ module.exports = {
   },
   path: {
     ...nopt.typeDefs.path,
+    validate: validatePath,
     description: 'valid filesystem path',
   },
   Number: {

--- a/test/type-defs.js
+++ b/test/type-defs.js
@@ -1,7 +1,22 @@
 const typeDefs = require('../lib/type-defs.js')
 const t = require('tap')
-const { semver: { validate: validateSemver }} = typeDefs
-const d = { semver: 'foobar' }
+const {
+  semver: {
+    validate: validateSemver,
+  },
+  path: {
+    validate: validatePath,
+  }
+} = typeDefs
+const { resolve } = require('path')
+
+const d = { semver: 'foobar', somePath: true }
 t.equal(validateSemver(d, 'semver', 'foobar'), false)
 t.equal(validateSemver(d, 'semver', 'v1.2.3'), undefined)
 t.equal(d.semver, '1.2.3')
+t.equal(validatePath(d, 'somePath', true), false)
+t.equal(validatePath(d, 'somePath', false), false)
+t.equal(validatePath(d, 'somePath', null), false)
+t.equal(validatePath(d, 'somePath', 1234), false)
+t.equal(validatePath(d, 'somePath', 'false'), true)
+t.equal(d.somePath, resolve('false'))


### PR DESCRIPTION
When running with `--no-cache`, it sets the 'cache' option to a boolean
'false', which was then coerced to a string by nopt.

We should allow users to specify any string, but `--no-...` makes it
_always_ be a boolean `false` which is surprising.  (Similarly if a path
is set to a `null` or some other non-strig value in a .npmrc config
file.)

This causes non-string `'path'` type options to fail validation, so that
they'll fall back to the default when set to an invalid value.

<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->


## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
