### PR TITLE
Restore npm v6 behavior with INIT_CWD

### DIFF
--- a/lib/set-envs.js
+++ b/lib/set-envs.js
@@ -59,7 +59,7 @@ const setEnvs = (config) => {
   else
     env.PREFIX = globalPrefix
 
-  env.INIT_CWD = env.INIT_CWD || process.cwd()
+  env.INIT_CWD = process.cwd()
 
   // if the key is the default value,
   //   if the environ is NOT the default value,

--- a/test/set-envs.js
+++ b/test/set-envs.js
@@ -53,14 +53,14 @@ t.test('set envs that are not defaults and not already in env, array style', t =
   const cliConf = Object.create(envConf)
   const extras = {
     NODE,
-    INIT_CWD: '/some/other/path',
+    INIT_CWD: cwd,
     EDITOR: 'vim',
     HOME: undefined,
     PREFIX: undefined,
     npm_execpath: require.main.filename,
     npm_node_execpath: execPath,
   }
-  // make sure it's sticky
+  // make sure it's not sticky
   const env = { INIT_CWD: '/some/other/path' }
   const config = { list: [cliConf, envConf], env, defaults, execPath }
   setEnvs(config)


### PR DESCRIPTION
This should always be set to the npm cwd, even if already in the env.

Fix: https://github.com/npm/cli/issues/2578

<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->


## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
