### PR TITLE
Do not export definitions with envExport:false

### DIFF
--- a/lib/set-envs.js
+++ b/lib/set-envs.js
@@ -67,8 +67,8 @@ const setEnvs = (config) => {
   const cliSet = new Set(Object.keys(cliConf))
   const envSet = new Set(Object.keys(envConf))
   for (const key in cliConf) {
-    const { deprecated } = definitions[key] || {}
-    if (deprecated)
+    const { deprecated, envExport = true } = definitions[key] || {}
+    if (deprecated || envExport === false)
       continue
 
     if (sameConfigValue(defaults[key], cliConf[key])) {

--- a/test/fixtures/defaults.js
+++ b/test/fixtures/defaults.js
@@ -1,4 +1,5 @@
 module.exports = {
+  methane: 'CH4',
   access: null,
   all: false,
   'allow-same-version': false,

--- a/test/fixtures/definitions.js
+++ b/test/fixtures/definitions.js
@@ -20,6 +20,15 @@ const maybeReadFile = file => {
 }
 
 const definitions = module.exports = {
+  methane: {
+    envExport: false,
+    type: String,
+    typeDescription: 'Greenhouse Gas',
+    default: 'CH4',
+    description: `
+      This is bad for the environment, for our children, do not put it there.
+    `,
+  },
   'multiple-numbers': {
     key: 'multiple-numbers',
     default: [],

--- a/test/set-envs.js
+++ b/test/set-envs.js
@@ -29,7 +29,6 @@ t.test('set envs that are not defaults and not already in env', t => {
   }
 
   setEnvs(config)
-
   t.strictSame(env, { ...extras }, 'no new environment vars to create')
   envConf.call = 'me, maybe'
   setEnvs(config)
@@ -97,7 +96,6 @@ t.test('set envs that are not defaults and not already in env, array style', t =
   t.end()
 })
 
-
 t.test('set envs that are not defaults and not already in env, boolean edition', t => {
   const envConf = Object.create(defaults)
   const cliConf = Object.create(envConf)
@@ -162,5 +160,33 @@ t.test('dont set npm_execpath if require.main.filename is not set', t => {
   }
   setEnvs(config)
   t.equal(env.npm_execpath, undefined, 'did not set npm_execpath')
+  t.end()
+})
+
+t.test('dont set configs marked as envExport:false', t => {
+  const envConf = Object.create(defaults)
+  const cliConf = Object.create(envConf)
+  const extras = {
+    NODE,
+    INIT_CWD: cwd,
+    EDITOR: 'vim',
+    HOME: undefined,
+    npm_execpath: require.main.filename,
+    npm_node_execpath: execPath,
+  }
+
+  const env = {}
+  const config = {
+    list: [cliConf, envConf],
+    env,
+    defaults,
+    definitions,
+    execPath,
+  }
+  setEnvs(config)
+  t.strictSame(env, { ...extras }, 'no new environment vars to create')
+  cliConf.methane = 'CO2'
+  setEnvs(config)
+  t.strictSame(env, { ...extras }, 'not exported, because envExport=false')
   t.end()
 })


### PR DESCRIPTION
We need this so that we don't make things weird by exporting `workspace` and `workspaces` into the environment.

<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->


## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
