### PR TITLE
Allow the local prefix to be set by an environment variable

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -521,6 +521,24 @@ class Config {
       return
     }
 
+    const envPrefix = this[_get]('prefix', 'env')
+    if (envPrefix) {
+      // check to see if the prefix from the env has a nm dir or pj file
+      const hasAny = (await Promise.all([
+        stat(resolve(envPrefix, 'node_modules'))
+          .then(st => st.isDirectory())
+          .catch(() => false),
+        stat(resolve(envPrefix, 'package.json'))
+          .then(st => st.isFile())
+          .catch(() => false),
+      ])).some(is => is)
+
+      if (hasAny) {
+        this.localPrefix = envPrefix
+        return
+      }
+    }
+
     for (const p of walkUp(this.cwd)) {
       // walk up until we have a nm dir or a pj file
       const hasAny = (await Promise.all([


### PR DESCRIPTION
# What / Why

In the npm config documentation, it states the following:

> Any environment variables that start with `npm_config_` will be interpreted as a configuration parameter. For example, putting `npm_config_foo=bar` in your environment will set the `foo `configuration parameter to `bar`.
>
> \- https://docs.npmjs.com/cli/v7/using-npm/config#environment-variables

With this in mind, I am attempting to use npm 7+ with workspaces in Gatsby Cloud. My directory structure looks like the following.

```
- monorepo/
  - package.json
  - package-lock.json
  - package-a/
    - package.json
    - index.js
```

Gatsby Cloud is extremely limited in terms of configuration and all I can do to provide build time configurations is environment variables and the path to do the building in. So, to build `package-a`, I need to be able to `npm ci` from within the context of `package-a`. Unfortunately, `npm ci` (correctly) does not traverse directories upwards if the current directory has a `package.json`.

(As a side note, yarn will automatically go up directories to find a lock file when doing an install requiring a lockfile, but that's neither here nor there, though could be used as prior art).

So I'm trying to find a way around this and realize that I *should* be able to provide an environment variable of `NPM_CONFIG_PREFIX=..` and have `npm ci` work perfectly without having to provide any arguments the command. Unfortunately, that is not the case.

```shell
/opt/monrepo/package-a $ NPM_CONFIG_PREFIX=.. npm ci
npm ERR! The `npm ci` command can only install with an existing package-lock.json or
npm ERR! npm-shrinkwrap.json with lockfileVersion >= 1. Run an install with npm@5 or
npm ERR! later to generate a package-lock.json file, then try again.
```

More confusingly, running the command with `--prefix=..` works like charm, which means I'm so very close to this working right!

```shell
/opt/monrepo/package-a $ npm ci --prefix=..
...
added 3373 packages, and audited 3383 packages in 3m
...
```

Now, here comes the fun part, `npm config` is properly setting this variable in it's config output!

```shell
/opt/monrepo/package-a $ NPM_CONFIG_PREFIX=.. npm config get -l prefix
/opt/monorepo
```

I do some digging in the npm CLI and realize that it's pulling the prefix value from the config in a slightly different way for CI vs `npm config` (I think `npm ci` is using `prefix` which is using `loadLocalPrefix` and config is going through "normal channels").

**This PR just adds support to set `prefix` using environment variables and only does so if the target directory has a `node_modules` directory or `package.json`.**

## Questions

1. I need to spend more time looking at the tests as they are a little confusing to me and I want to get this PR to 100% coverage.
2. I'm assuming that this was a conscious decision to have special handling for the `prefix` and since y'all look at a lot more npm issues than me, is there a chance this might break something? I think the additional checks for if the PJ.json or NM directory should make this pretty safe.
3. Should I print a warning to the console if a `node_modules` directory or `package.json` does not exist in the path that the prefix is pointing to?
4. I also noticed that setting the `prefix` in a local `.npmrc` does not allow `npm ci` to work? Should I add handling for that as well?

## References

* https://docs.npmjs.com/cli/v7/using-npm/config#environment-variables
* https://docs.npmjs.com/cli/v7/using-npm/config#prefix
* https://github.com/npm/cli/blob/latest/lib/ci.js#L53
