### PR TITLE
fix: dont load project configs in global mode

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -497,6 +497,12 @@ class Config {
   }
 
   async loadProjectConfig () {
+    if (this[_get]('global') === true || this[_get]('location') === 'global') {
+      this.data.get('project').source = '(global mode enabled, ignored)'
+      this.sources.set(this.data.get('project').source, 'project')
+      return
+    }
+
     // the localPrefix can be set by the CLI config, but otherwise is
     // found by walking up the folder tree
     await this.loadLocalPrefix()

--- a/test/fixtures/definitions.js
+++ b/test/fixtures/definitions.js
@@ -985,6 +985,14 @@ const definitions = module.exports = {
     },
     defaultDescription: 'null',
   },
+  location: {
+    key: 'location',
+    default: 'user',
+    type: ['global', 'user', 'project'],
+    description: '\n    When passed to \`npm config\` this refers to which config file to use.',
+    defaultDescription: '\n    "user" unless \`--global\` is passed, which will also set this value to "global"',
+    typeDescription: '"global", "user", or "project"',
+  },
   loglevel: {
     key: 'loglevel',
     default: 'notice',

--- a/test/index.js
+++ b/test/index.js
@@ -174,6 +174,38 @@ loglevel = yolo
     })
   })
 
+  t.test('dont load project config if global is true', async t => {
+    const config = new Config({
+      npmPath: `${path}/npm`,
+      env: {},
+      argv: [process.execPath, __filename, '--global'],
+      cwd: `${path}/project`,
+      shorthands,
+      definitions,
+    })
+
+    await config.load()
+    const source = config.data.get('project').source
+    t.equal(source, '(global mode enabled, ignored)', 'data has placeholder')
+    t.equal(config.sources.get(source), 'project', 'sources has project')
+  })
+
+  t.test('dont load project config if location is global', async t => {
+    const config = new Config({
+      npmPath: `${path}/npm`,
+      env: {},
+      argv: [process.execPath, __filename, '--location', 'global'],
+      cwd: `${path}/project`,
+      shorthands,
+      definitions,
+    })
+
+    await config.load()
+    const source = config.data.get('project').source
+    t.equal(source, '(global mode enabled, ignored)', 'data has placeholder')
+    t.equal(config.sources.get(source), 'project', 'sources has project')
+  })
+
   t.test('verbose log if config file read is weird error', async t => {
     const config = new Config({
       npmPath: path,


### PR DESCRIPTION
if we're operating in global mode, there is no reason at all to load the project level config, so let's not do that