### PR TITLE
fix: always load localPrefix

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -497,15 +497,17 @@ class Config {
   }
 
   async loadProjectConfig () {
+    // the localPrefix can be set by the CLI config, but otherwise is
+    // found by walking up the folder tree. either way, we load it before
+    // we return to make sure localPrefix is set
+    await this.loadLocalPrefix()
+
     if (this[_get]('global') === true || this[_get]('location') === 'global') {
       this.data.get('project').source = '(global mode enabled, ignored)'
       this.sources.set(this.data.get('project').source, 'project')
       return
     }
 
-    // the localPrefix can be set by the CLI config, but otherwise is
-    // found by walking up the folder tree
-    await this.loadLocalPrefix()
     const projectFile = resolve(this.localPrefix, '.npmrc')
     // if we're in the ~ directory, and there happens to be a node_modules
     // folder (which is not TOO uncommon, it turns out), then we can end

--- a/test/index.js
+++ b/test/index.js
@@ -204,6 +204,7 @@ loglevel = yolo
     const source = config.data.get('project').source
     t.equal(source, '(global mode enabled, ignored)', 'data has placeholder')
     t.equal(config.sources.get(source), 'project', 'sources has project')
+    t.ok(config.localPrefix, 'localPrefix is set')
   })
 
   t.test('verbose log if config file read is weird error', async t => {


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
several code paths expect `localPrefix` to be set, even in global mode. when this was changed to not load project configs when operating in global mode that got broken. this shuffles things so that `localPrefix` will be set no matter what, allowing globally installed run scripts to work correctly.

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
Fixes https://github.com/npm/cli/issues/4015