### PR TITLE
chore: switch dependbot rule to increase

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
     interval: daily
   allow:
     - dependency-type: direct
-  versioning-strategy: increase-if-necessary
+  versioning-strategy: increase
   commit-message:
     prefix: deps
     prefix-development: chore


### PR DESCRIPTION
The next template-oss does this but we want to see if the dependabot PRs for template-oss itself will update the files i.e. run postinstall.