### PR TITLE
fix: skip workspace detection when in global mode

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -566,6 +566,7 @@ class Config {
     }
 
     const cliWorkspaces = this[_get]('workspaces', 'cli')
+    const isGlobal = this[_get]('global') || this[_get]('location') === 'global'
 
     for (const p of walkUp(this.cwd)) {
       const hasNodeModules = await stat(resolve(p, 'node_modules'))
@@ -579,8 +580,8 @@ class Config {
       if (!this.localPrefix && (hasNodeModules || hasPackageJson)) {
         this.localPrefix = p
 
-        // if workspaces are disabled, return now
-        if (cliWorkspaces === false) {
+        // if workspaces are disabled, or we're in global mode, return now
+        if (cliWorkspaces === false || isGlobal) {
           return
         }
 

--- a/test/index.js
+++ b/test/index.js
@@ -1137,6 +1137,46 @@ t.test('workspaces', async (t) => {
     t.equal(logs.length, 0, 'got no log messages')
   })
 
+  t.test('global skips auto detect', async (t) => {
+    const cwd = process.cwd()
+    t.teardown(() => process.chdir(cwd))
+    process.chdir(`${path}/workspaces/one`)
+
+    const config = new Config({
+      npmPath: process.cwd(),
+      env: {},
+      argv: [process.execPath, __filename, '--global'],
+      cwd: `${path}/workspaces/one`,
+      shorthands,
+      definitions,
+    })
+
+    await config.load()
+    t.equal(config.localPrefix, join(path, 'workspaces', 'one'), 'localPrefix is the root')
+    t.same(config.get('workspace'), [], 'did not set workspace')
+    t.equal(logs.length, 0, 'got no log messages')
+  })
+
+  t.test('location=global skips auto detect', async (t) => {
+    const cwd = process.cwd()
+    t.teardown(() => process.chdir(cwd))
+    process.chdir(`${path}/workspaces/one`)
+
+    const config = new Config({
+      npmPath: process.cwd(),
+      env: {},
+      argv: [process.execPath, __filename, '--location=global'],
+      cwd: `${path}/workspaces/one`,
+      shorthands,
+      definitions,
+    })
+
+    await config.load()
+    t.equal(config.localPrefix, join(path, 'workspaces', 'one'), 'localPrefix is the root')
+    t.same(config.get('workspace'), [], 'did not set workspace')
+    t.equal(logs.length, 0, 'got no log messages')
+  })
+
   t.test('does not error for invalid package.json', async (t) => {
     const invalidPkg = join(path, 'workspaces', 'package.json')
     const cwd = process.cwd()


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
if we apply auto detection in global mode, several commands will fail with an error that workspaces aren't supported in global mode

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
Closes npm/cli#4477