### PR TITLE
fix: replace deprecated String.prototype.substr()

### DIFF
--- a/lib/env-replace.js
+++ b/lib/env-replace.js
@@ -7,8 +7,8 @@ module.exports = (f, env) => f.replace(envExpr, (orig, esc, name) => {
 
   // consume the escape chars that are relevant.
   if (esc.length % 2) {
-    return orig.substr((esc.length + 1) / 2)
+    return orig.slice((esc.length + 1) / 2)
   }
 
-  return (esc.substr(esc.length / 2)) + val
+  return (esc.slice(esc.length / 2)) + val
 })

--- a/lib/index.js
+++ b/lib/index.js
@@ -366,7 +366,7 @@ class Config {
       if (!/^npm_config_/i.test(envKey) || envVal === '') {
         continue
       }
-      const key = envKey.substr('npm_config_'.length)
+      const key = envKey.slice('npm_config_'.length)
         .replace(/(?!^)_/g, '-') // don't replace _ at the start of the key
         .toLowerCase()
       conf[key] = envVal

--- a/lib/parse-field.js
+++ b/lib/parse-field.js
@@ -56,7 +56,7 @@ const parseField = (f, key, opts, listElement = false) => {
   if (isPath) {
     const homePattern = platform === 'win32' ? /^~(\/|\\)/ : /^~\//
     if (homePattern.test(f) && home) {
-      f = resolve(home, f.substr(2))
+      f = resolve(home, f.slice(2))
     } else {
       f = resolve(f)
     }


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.