### PR TITLE
[WIP] feat: Add ability to deprecate singular config values

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -98,11 +98,15 @@ class Config {
     const types = {}
     const defaults = {}
     this.deprecated = {}
+    this.deprecatedValues = {}
     for (const [key, def] of Object.entries(definitions)) {
       defaults[key] = def.default
       types[key] = def.type
       if (def.deprecated) {
         this.deprecated[key] = def.deprecated.trim().replace(/\n +/, '\n')
+      }
+      if (def.deprecatedValues) {
+        this.deprecatedValues[key] = def.deprecatedValues
       }
     }
 
@@ -507,7 +511,13 @@ class Config {
 
   [_checkDeprecated] (key, where, obj, kv) {
     // XXX(npm9+) make this throw an error
-    if (this.deprecated[key]) {
+    const value = obj[key]
+    const hasDeprecatedValues = Array.isArray(this.deprecatedValues[key])
+    const warn =
+      (hasDeprecatedValues && this.deprecatedValues[key].includes(value)) ||
+      (!hasDeprecatedValues && this.deprecated[key])
+
+    if (warn) {
       log.warn('config', key, this.deprecated[key])
     }
   }


### PR DESCRIPTION
## What
Add the ability to deprecate single values for options, instead of just whole options.

Allows definitions to have a `deprecatedValues` array, that lists the values that are deprecated.

## Why
Allows for instance the `--auth-type` configuration option to have non-deprecated as well as deprecated values.

## References
- https://github.com/github/npm/issues/5542
- https://github.com/npm/cli/pull/5115