### PR TITLE
fix: correctly handle nerf-darted env vars

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -367,9 +367,11 @@ class Config {
       if (!/^npm_config_/i.test(envKey) || envVal === '') {
         continue
       }
-      const key = envKey.slice('npm_config_'.length)
-        .replace(/(?!^)_/g, '-') // don't replace _ at the start of the key
-        .toLowerCase()
+      let key = envKey.slice('npm_config_'.length)
+      if (!key.startsWith('//')) { // don't normalize nerf-darted keys
+        key = key.replace(/(?!^)_/g, '-') // don't replace _ at the start of the key
+          .toLowerCase()
+      }
       conf[key] = envVal
     }
     this[_loadObject](conf, 'env', 'environment')
@@ -693,8 +695,6 @@ class Config {
       this.delete(`_password`, 'user')
       this.delete(`username`, 'user')
     }
-    this.delete(`${nerfed}:-authtoken`, 'user')
-    this.delete(`${nerfed}:_authtoken`, 'user')
     this.delete(`${nerfed}:_authToken`, 'user')
     this.delete(`${nerfed}:_auth`, 'user')
     this.delete(`${nerfed}:_password`, 'user')
@@ -734,8 +734,6 @@ class Config {
     // send auth if we have it, only to the URIs under the nerf dart.
     this.delete(`${nerfed}:always-auth`, 'user')
 
-    this.delete(`${nerfed}:-authtoken`, 'user')
-    this.delete(`${nerfed}:_authtoken`, 'user')
     this.delete(`${nerfed}:email`, 'user')
     if (certfile && keyfile) {
       this.set(`${nerfed}:certfile`, certfile, 'user')
@@ -783,8 +781,6 @@ class Config {
     }
 
     const tokenReg = this.get(`${nerfed}:_authToken`) ||
-      this.get(`${nerfed}:_authtoken`) ||
-      this.get(`${nerfed}:-authtoken`) ||
       nerfed === nerfDart(this.get('registry')) && this.get('_authToken')
 
     if (tokenReg) {

--- a/tap-snapshots/test/index.js.test.cjs
+++ b/tap-snapshots/test/index.js.test.cjs
@@ -109,22 +109,6 @@ exports[`test/index.js TAP credentials management nerfed_authToken > other regis
 Object {}
 `
 
-exports[`test/index.js TAP credentials management nerfed_lcAuthToken > default registry 1`] = `
-Object {
-  "token": "0bad1de4",
-}
-`
-
-exports[`test/index.js TAP credentials management nerfed_lcAuthToken > default registry after set 1`] = `
-Object {
-  "token": "0bad1de4",
-}
-`
-
-exports[`test/index.js TAP credentials management nerfed_lcAuthToken > other registry 1`] = `
-Object {}
-`
-
 exports[`test/index.js TAP credentials management nerfed_mtls > default registry 1`] = `
 Object {
   "certfile": "/path/to/cert",


### PR DESCRIPTION
Preserve nerf-darted keys verbatim, since the downcasing and dasherizing can mess up both the URIs and the sub-keys themselves.

This will allow you to successfully use env vars to control registry auth, e.g. `npm_config_//reg.example/UP_CASE/:_authToken=secret` will result in a `//reg.example/UP_CASE/:_authToken` config

See #64 for more context, but the key details to note are:
1. The current logic can mess up URIs (paths may be case-sensitive, and underscores get converted to dashes)
2. The current logic dasherizes the prefix (e.g. `_password` becomes `-password`), which `npm-registry-fetch` does not handle.
3. The current logic downcases `authToken` ... although `getCredentialsByURI` has some handling around `authtoken` (and the `-` prefix), it doesn't really matter because `npm-registry-fetch` does not, so it won't get used.
4. Regarding case-sensitivity and env variables, based on my testing this should be safe/portable because:
   * For Linux/Mac/etc. variables are case-sensitive and you can use unusual characters in names
   * For Windows, although env var *accesses* are case-insensitive, the original case of the variable name is preserved when iterating or otherwise retrieving the keys, so we can reasonably pull a case-sensitive registry prefix from the key

## References
Fixes #64